### PR TITLE
Add missing "by exact"

### DIFF
--- a/Tutorials/Exercises/02IffIfAnd.lean
+++ b/Tutorials/Exercises/02IffIfAnd.lean
@@ -54,7 +54,7 @@ In addition, recall that curly braces around `a b` mean Lean will figure out tho
 insist to help. This is because they can be deduced from the next argument `hab`.
 So it will be sufficient to feed `hab` and `c` to this function.
 -/
-example (a b : ℝ) (ha : 0 ≤ a) : b ≤ a + b := by
+example {a b : ℝ} (ha : 0 ≤ a) : b ≤ a + b := by
   calc
     b = 0 + b := by ring
     _ ≤ a + b := by exact add_le_add_right ha b

--- a/Tutorials/Exercises/02IffIfAnd.lean
+++ b/Tutorials/Exercises/02IffIfAnd.lean
@@ -54,10 +54,10 @@ In addition, recall that curly braces around `a b` mean Lean will figure out tho
 insist to help. This is because they can be deduced from the next argument `hab`.
 So it will be sufficient to feed `hab` and `c` to this function.
 -/
-example {a b : ℝ} (ha : 0 ≤ a) : b ≤ a + b := by
+example (a b : ℝ) (ha : 0 ≤ a) : b ≤ a + b := by
   calc
     b = 0 + b := by ring
-    _ ≤ a + b := add_le_add_right ha b
+    _ ≤ a + b := by exact add_le_add_right ha b
 
 
 /-

--- a/Tutorials/Solutions/02IffIfAnd.lean
+++ b/Tutorials/Solutions/02IffIfAnd.lean
@@ -60,7 +60,7 @@ In addition, recall that curly braces around `a b` mean Lean will figure out tho
 insist to help. This is because they can be deduced from the next argument `hab`.
 So it will be sufficient to feed `hab` and `c` to this function.
 -/
-example (a b : ℝ) (ha : 0 ≤ a) : b ≤ a + b := by
+example {a b : ℝ} (ha : 0 ≤ a) : b ≤ a + b := by
   calc
     b = 0 + b := by ring
     _ ≤ a + b := by exact add_le_add_right ha b

--- a/Tutorials/Solutions/02IffIfAnd.lean
+++ b/Tutorials/Solutions/02IffIfAnd.lean
@@ -60,10 +60,10 @@ In addition, recall that curly braces around `a b` mean Lean will figure out tho
 insist to help. This is because they can be deduced from the next argument `hab`.
 So it will be sufficient to feed `hab` and `c` to this function.
 -/
-example {a b : ℝ} (ha : 0 ≤ a) : b ≤ a + b := by
+example (a b : ℝ) (ha : 0 ≤ a) : b ≤ a + b := by
   calc
     b = 0 + b := by ring
-    _ ≤ a + b := add_le_add_right ha b
+    _ ≤ a + b := by exact add_le_add_right ha b
 
 
 /-


### PR DESCRIPTION
I think the following comment speaks about skipping `by exact`, but that only makes sense if it is there in the previous example, right?

Otherwise, the two examples are identical (except for the braces, which I also unified).